### PR TITLE
Use new extension API for 1.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ endif
 
 OSQUERY_BUILD := $(OSQUERY_DIR)/build/$(BUILD_DIRNAME)
 OSQUERY_BINARY := $(OSQUERY_BUILD)/osquery/osqueryd
+OSQUERY_SHELL := $(OSQUERY_BUILD)/osquery/osqueryi
+API_QUERY := "select substr(version, 0, 6) as api from osquery_info;"
+API_VERSION := $(shell $(OSQUERY_SHELL) --header=false --csv $(API_QUERY))
 
 ifeq (,$(wildcard $(OSQUERY_BUILD)))
 $(error Could not find the build directory - have you compiled osquery?)
@@ -21,7 +24,9 @@ endif
 CC := gcc
 CXX := g++
 
-CPPFLAGS := -g -I $(OSQUERY_DIR)/include/
+CPPFLAGS := \
+	-g -I $(OSQUERY_DIR)/include/ \
+	-DOSQUERY_BUILD_SDK_VERSION=$(API_VERSION)
 CFLAGS :=
 CXXFLAGS := -std=c++11
 

--- a/osquery_profiles.cpp
+++ b/osquery_profiles.cpp
@@ -296,9 +296,10 @@ int main(int argc, char* argv[]) {
   auto status = startExtension("profiles", "0.0.1");
   if (!status.ok()) {
     LOG(ERROR) << status.getMessage();
+    runner.requestShutdown(status.getCode());
   }
 
-  // Finally shutdown.
-  runner.shutdown();
+  // Finally wait for a signal / interrupt to shutdown.
+  runner.waitForShutdown();
   return 0;
 }


### PR DESCRIPTION
If you want we can support both the old API `::shutdown()` and the new `::waitForShutdown()` using the API version define. Or if that's not a problem and the next time this is deployed it uses 1.7.2+ then let's just move to the new "safer" flow.
